### PR TITLE
feat: exclude assemblies by wildcard

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,7 @@ dotnet tool install --global Alias
 assemblyalias --target-directory "C:/Code/TargetDirectory"
               --suffix _Alias
               --assemblies-to-alias "Microsoft*;System*;EmptyFiles"
+              --assemblies-to-exclude "e_sqlite*"
 ```
 
 
@@ -91,7 +92,7 @@ Required. A semi-colon separated list of assembly names to alias. Names ending i
 
 `-e` or `--assemblies-to-exclude`
 
-Optional. A semi-colon separated list of assembly names to exclude.
+Optional. A semi-colon separated list of assembly names to exclude. Names ending in `*` are treated as wildcards.
 
 
 #### Key

--- a/src/Alias.Lib/ModuleReaderWriter.cs
+++ b/src/Alias.Lib/ModuleReaderWriter.cs
@@ -56,6 +56,13 @@ static class ModuleReaderWriter
             parameters.StrongNameKeyPair = key;
         }
 
-        module.Write(file, parameters);
+        try
+        {
+            module.Write(file, parameters);
+        }
+        catch (Exception ex)
+        {
+            throw new($"Could not write module {file}", ex);
+        }
     }
 }

--- a/src/Alias/Alias.csproj
+++ b/src/Alias/Alias.csproj
@@ -9,6 +9,7 @@
     <GeneratePackageOnBuild Condition="$(Configuration) == 'Release'">true</GeneratePackageOnBuild>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)key.snk</AssemblyOriginatorKeyFile>
+    <Version>0.4.4</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(SolutionDir)icon.png" Pack="true" PackagePath="\" />

--- a/src/Alias/Finder.cs
+++ b/src/Alias/Finder.cs
@@ -58,4 +58,39 @@ public static class Finder
             }
         }
     }
+    
+    public static IEnumerable<string> FilterAssemblies(
+        IEnumerable<string> assemblyNamesToExclude,
+        IEnumerable<string> allFiles)
+    {
+        assemblyNamesToExclude = assemblyNamesToExclude.ToList();
+
+        foreach (var file in allFiles)
+        {
+            var name = Path.GetFileNameWithoutExtension(file);
+            var isMatch = false;
+            foreach (var assemblyToExclude in assemblyNamesToExclude)
+            {
+                if (assemblyToExclude.EndsWith('*'))
+                {
+                    var match = assemblyToExclude.TrimEnd('*');
+                    if (name.StartsWith(match))
+                    {
+                        isMatch = true;
+                    }
+                    continue;
+                }
+
+                if (name == assemblyToExclude)
+                {
+                    isMatch = true;
+                }
+            }
+
+            if (!isMatch)
+            {
+                yield return file;
+            }
+        }
+    }
 }

--- a/src/Alias/Program.cs
+++ b/src/Alias/Program.cs
@@ -41,7 +41,9 @@ public static class Program
         Action<string> log)
     {
         var list = Directory.GetFiles(directory, "*.dll", SearchOption.AllDirectories).ToList();
-        var allFiles = list.Where(x => !assembliesToExclude.Contains(x));
+        
+        var allFiles = Finder.FilterAssemblies(assembliesToExclude, list)
+            .ToList();
 
         var assemblyInfos = Finder.FindAssemblyInfos(assemblyNamesToAlias, allFiles, prefix, suffix)
             .ToList();


### PR DESCRIPTION
Currently, the method checking what assemblies to exclude is not ideal as, for it to work, it checks if the `assemblyToExclude` string contains the full path to a DLL. Therefore we need to pass a list of full paths.

 This PR makes it possible to exclude assemblies by wildcard just like for the assets to include:

![image](https://user-images.githubusercontent.com/2679513/234035337-67bd639d-619f-4e05-8ed8-ac14d21a363c.png)
