### PR TITLE
fix: assemblies to exclude

### DIFF
--- a/src/Alias/Finder.cs
+++ b/src/Alias/Finder.cs
@@ -5,6 +5,7 @@ public static class Finder
     public static IEnumerable<SourceTargetInfo> FindAssemblyInfos(
         IEnumerable<string> assemblyNamesToAlias,
         IEnumerable<string> allFiles,
+        IEnumerable<string> assemblyNamesToExclude,
         string? prefix,
         string? suffix)
     {
@@ -13,21 +14,30 @@ public static class Finder
             throw new ErrorException("Either prefix or suffix must be defined.");
         }
 
-        return FindAssemblyInfos(assemblyNamesToAlias, allFiles, name => $"{prefix}{name}{suffix}");
+        return FindAssemblyInfos(assemblyNamesToAlias, allFiles, assemblyNamesToExclude, name => $"{prefix}{name}{suffix}");
     }
 
     static IEnumerable<SourceTargetInfo> FindAssemblyInfos(
         IEnumerable<string> assemblyNamesToAlias,
         IEnumerable<string> allFiles,
+        IEnumerable<string> assemblyNamesToExclude,
         Func<string, string> getTargetName)
     {
         assemblyNamesToAlias = assemblyNamesToAlias.ToList();
+        var namesToExclude = assemblyNamesToExclude.ToList();
 
         foreach (var file in allFiles)
         {
             var name = Path.GetFileNameWithoutExtension(file);
             var fileDirectory = Path.GetDirectoryName(file)!;
             var isAliased = false;
+
+            if (IsExcluded(name, namesToExclude))
+            {
+                yield return new(name, file, name, file, false);
+                continue;
+            }
+
             foreach (var assemblyToAlias in assemblyNamesToAlias)
             {
                 var targetName = getTargetName(name);
@@ -57,5 +67,28 @@ public static class Finder
                 yield return new(name, file, name, file, false);
             }
         }
+    }
+
+    static bool IsExcluded(string name, IEnumerable<string> namesToExclude)
+    {
+        foreach (var exclude in namesToExclude)
+        {
+            if (exclude.EndsWith('*'))
+            {
+                if (name.StartsWith(exclude.TrimEnd('*')))
+                {
+                    return true;
+                }
+
+                continue;
+            }
+
+            if (name == exclude)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Alias/Program.cs
+++ b/src/Alias/Program.cs
@@ -40,10 +40,9 @@ public static class Program
         bool internalize,
         Action<string> log)
     {
-        var list = Directory.GetFiles(directory, "*.dll", SearchOption.AllDirectories).ToList();
-        var allFiles = list.Where(x => !assembliesToExclude.Contains(x));
+        var allFiles = Directory.GetFiles(directory, "*.dll", SearchOption.AllDirectories);
 
-        var assemblyInfos = Finder.FindAssemblyInfos(assemblyNamesToAlias, allFiles, prefix, suffix)
+        var assemblyInfos = Finder.FindAssemblyInfos(assemblyNamesToAlias, allFiles, assembliesToExclude, prefix, suffix)
             .ToList();
 
         var builder = new StringBuilder("Resolved assemblies to alias:");

--- a/src/Tests/Tests.cs
+++ b/src/Tests/Tests.cs
@@ -173,6 +173,16 @@ public class Tests
 
 #if DEBUG
 
+    // Assemblies excluded from aliasing in RunSample. Shared between the aliasing
+    // call and PatchDependencies so the two can never drift: an excluded assembly
+    // keeps its original name on disk, so its deps.json entry must not be rewritten
+    // to Alias_* (doing so makes the runtime probe for a file that doesn't exist).
+    static readonly List<string> sampleExcludes = new()
+    {
+        "AssemblyToInclude",
+        "AssemblyToProcess"
+    };
+
     [Fact]
     public async Task RunSample()
     {
@@ -194,11 +204,7 @@ public class Tests
             },
             references: new(),
             keyFile: null,
-            assembliesToExclude: new()
-            {
-                "AssemblyToInclude",
-                "AssemblyToProcess"
-            },
+            assembliesToExclude: sampleExcludes,
             prefix: "Alias_",
             suffix: null,
             internalize: true,
@@ -227,6 +233,11 @@ public class Tests
         var depsFile = Path.Combine(targetPath, "SampleApp.deps.json");
         var text = File.ReadAllText(depsFile);
         text = text.Replace("Assembly", "Alias_Assembly");
+        foreach (var name in sampleExcludes)
+        {
+            text = text.Replace($"Alias_{name}", name);
+        }
+
         File.Delete(depsFile);
         File.WriteAllText(depsFile, text);
     }


### PR DESCRIPTION
Providing assemblies to be excluded from the aliasing got skipped.